### PR TITLE
Add a bors-do-not-land label

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ Options for Pull Requests are configured through the application of labels.
 | ![label: bors-high-priority](https://img.shields.io/static/v1?label=&message=bors-high-priority&color=lightgrey) | Indicates that the PR is high-priority. When queued the PR will be placed at the head of the merge queue. |
 | ![label: bors-low-priority](https://img.shields.io/static/v1?label=&message=bors-low-priority&color=lightgrey) | Indicates that the PR is low-priority. When queued the PR will be placed at the back of the merge queue. |
 | ![label: bors-squash](https://img.shields.io/static/v1?label=&message=bors-squash&color=lightgrey) | Before merging the PR will be squashed down to a single commit, only retaining the commit message of the first commit in the PR. |
+| ![label: bors-do-not-land](https://img.shields.io/static/v1?label=&message=bors-do-not-land&color=lightgrey) | Prevents landing of the PR

--- a/bors/src/config.rs
+++ b/bors/src/config.rs
@@ -110,12 +110,17 @@ impl RepoConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Labels {
+    do_not_land: Option<String>,
     squash: Option<String>,
     high_priority: Option<String>,
     low_priority: Option<String>,
 }
 
 impl Labels {
+    pub fn do_not_land(&self) -> &str {
+        self.do_not_land.as_deref().unwrap_or("bors-do-not-land")
+    }
+
     pub fn squash(&self) -> &str {
         self.squash.as_deref().unwrap_or("bors-squash")
     }


### PR DESCRIPTION
This label prevents someone from accidentally landing code that is
not fit for production, but is in a draft state or otherwise for
testing or work in process purposes.
