### PR TITLE
[canary] Only allow one to run at once

### DIFF
--- a/bors/src/project_board.rs
+++ b/bors/src/project_board.rs
@@ -1,3 +1,4 @@
+use crate::event_processor::ActivePullRequestContext;
 use crate::{
     config::RepoConfig,
     graphql::GithubClient,
@@ -186,7 +187,6 @@ impl ProjectBoard {
         let canary_column =
             Self::unwrap_or_create_column(canary_column, CANARY_COLUMN_NAME, project_id, github)
                 .await?;
-
         Ok((review_column, queued_column, testing_column, canary_column))
     }
 
@@ -261,7 +261,14 @@ impl ProjectBoard {
         Ok(())
     }
 
-    async fn list_cards(github: &GithubClient, column_id: u64) -> Result<Vec<ProjectCard>> {
+    pub async fn list_canary_cards(
+        &self,
+        ctx: &ActivePullRequestContext<'_>,
+    ) -> Result<Vec<ProjectCard>> {
+        Self::list_cards(ctx.github(), self.canary_column.id).await
+    }
+
+    pub async fn list_cards(github: &GithubClient, column_id: u64) -> Result<Vec<ProjectCard>> {
         let mut list_options = ListProjectCardsOptions {
             archived_state: None,
             pagination_options: PaginationOptions {

--- a/github/src/webhook.rs
+++ b/github/src/webhook.rs
@@ -50,7 +50,10 @@ impl Webhook {
                 );
                 signature == hash
             } else {
-                warn!("[webhook {}] Invalid signature header {}", self.delivery_id, signature);
+                warn!(
+                    "[webhook {}] Invalid signature header {}",
+                    self.delivery_id, signature
+                );
                 false
             }
         } else {

--- a/github/src/webhook.rs
+++ b/github/src/webhook.rs
@@ -38,24 +38,15 @@ impl Webhook {
             return false;
         }
 
-        // Signature should have `sha256=` in front
         if let Some(ref signature) = self.signature_256 {
-            if !signature.starts_with("sha256=") {
-                let hash = hex::encode(hmac_sha256::HMAC::mac(&self.body, key.unwrap()));
-                let signature = &signature["sha256=".len()..];
+            let hash = hex::encode(hmac_sha256::HMAC::mac(&self.body, key.unwrap()));
+            let signature = &signature["sha256=".len()..];
 
-                debug!(
-                    "[webhook {}] SHA-256 Found: {} Expected: {}",
-                    self.delivery_id, signature, hash
-                );
-                signature == hash
-            } else {
-                warn!(
-                    "[webhook {}] Invalid signature header {}",
-                    self.delivery_id, signature
-                );
-                false
-            }
+            debug!(
+                "[webhook {}] SHA-256 Found: {} Expected: {}",
+                self.delivery_id, signature, hash
+            );
+            signature == hash
         } else {
             // There is no signature, reject it
             warn!("[webhook {}] No signature present", self.delivery_id);


### PR DESCRIPTION
This is a hack that needs to be tested against the real bors, but it should keep from sending a canary twice.

Example of it working:
https://github.com/aptos-labs/aptos-core/pull/356

Resolves https://github.com/aptos-labs/bors/issues/6